### PR TITLE
Update keycloak version to 8.0.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jboss/keycloak
+FROM jboss/keycloak:8.0.2
 COPY standalone-ha.xml /opt/jboss/keycloak/standalone/configuration/
 COPY govuk/ /opt/jboss/keycloak/themes/govuk/
 COPY templates/sms-validation* /opt/jboss/keycloak/themes/base/login/


### PR DESCRIPTION
Current keycloak version used 7.0.1 out of date

Version 8.0.2 makes changes to the API

Set the Keycloak version to use in Dockerfile to prevent automatic upgrades in version