### PR TITLE
Upgrade Keycloak to latest version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,3 @@
-FROM jboss/keycloak
+FROM jboss/keycloak:9.0.0
 COPY standalone-ha.xml /opt/jboss/keycloak/standalone/configuration/
 COPY govuk/ /opt/jboss/keycloak/themes/govuk/
-COPY templates/sms-validation* /opt/jboss/keycloak/themes/base/login/
-COPY templates/messages/messages_en.properties /tmp/
-COPY target/keycloak-sms-authenticator-sns-*.jar /opt/jboss/keycloak/standalone/deployments/
-RUN cat /tmp/messages_en.properties >> /opt/jboss/keycloak/themes/base/login/messages/messages_en.properties

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,20 +24,6 @@ pipeline {
                     stash includes: "govuk/**", name: "govuk"
                 }
             }
-            stage('Build SMS 2FA') {
-                agent {
-                    ecs {
-                        inheritFrom 'maven'
-                    }
-                }
-                steps {
-                    checkout([$class: 'GitSCM', branches: [[name: '*/develop']], userRemoteConfigs: [[url: 'https://github.com/nationalarchives/keycloak-sms-authenticator-sns.git']]])
-                    sh '/apache-maven-3.6.3/bin/mvn package'
-                    stash includes: "target/keycloak-sms-authenticator-sns-*.jar", name: "sms-authenticator"
-                    stash includes: "templates/sms-*", name: "sms-templates"
-                    stash includes: "templates/messages/messages_en.properties", name: "messages"
-                }
-            }
         }
     }
 
@@ -48,9 +34,6 @@ pipeline {
         steps {
             sh "rm -rf target"
             unstash 'govuk'
-            unstash 'sms-authenticator'
-            unstash 'sms-templates'
-            unstash 'messages'
             sh "docker build -t nationalarchives/tdr-auth-server:${params.STAGE} ."
             withCredentials([usernamePassword(credentialsId: "docker", usernameVariable: "USERNAME", passwordVariable: "PASSWORD")]) {
                 sh "echo $PASSWORD | docker login --username $USERNAME --password-stdin"

--- a/standalone-ha.xml
+++ b/standalone-ha.xml
@@ -43,11 +43,6 @@
                 </authorization>
             </security-realm>
             <security-realm name="ApplicationRealm">
-                <server-identities>
-                    <ssl>
-                        <keystore path="application.keystore" relative-to="jboss.server.config.dir" keystore-password="password" alias="server" key-password="password" generate-self-signed-certificate-host="localhost"/>
-                    </ssl>
-                </server-identities>
                 <authentication>
                     <local default-user="$local" allowed-users="*" skip-group-loading="true"/>
                     <properties path="application-users.properties" relative-to="jboss.server.config.dir"/>
@@ -609,7 +604,6 @@
             <server name="default-server">
                 <ajp-listener name="ajp" socket-binding="ajp"/>
                 <http-listener name="default" socket-binding="http" redirect-socket="https" proxy-address-forwarding="true" enable-http2="true"/>
-                <https-listener name="https" socket-binding="https" proxy-address-forwarding="true" security-realm="ApplicationRealm" enable-http2="true"/>
                 <host name="default-host" alias="localhost">
                     <location name="/" handler="welcome-content"/>
                     <http-invoker security-realm="ApplicationRealm"/>


### PR DESCRIPTION
Upgrade to Keycloak version 9.0.0

Version specified to prevent unplanned upgrades between versions

Removed SSL keystore configuration as identified as a security risk

Removed SMS authentication as not needed currently. Library introduced errors into application