### PR TITLE
Fix tdr-fe client weborigin replacement values

### DIFF
--- a/environment-properties/intg_properties.json
+++ b/environment-properties/intg_properties.json
@@ -17,8 +17,8 @@
         "http://localhost:9000/*"
       ],
       "webOrigins": [
-        "https://tdr-integration.nationalarchives.gov.uk/*",
-        "http://localhost:9000/*"
+        "https://tdr-integration.nationalarchives.gov.uk",
+        "http://localhost:9000"
       ]
     }
   }


### PR DESCRIPTION
In existing intg Keycloak configuration values were set without '/*'

Having '/*' appended to the web origin was causing the tdr-fe login at upload to fail