### PR TITLE
Remove delay when running end-to-end tests after update

### DIFF
--- a/Jenkinsfile-update
+++ b/Jenkinsfile-update
@@ -58,7 +58,7 @@ pipeline {
           message: "*Auth server* :arrow_up: The Keycloak auth app has been updated with latest configuration in the *${params.STAGE}* environment"
         )
         if (params.STAGE == "intg") {
-          tdr.runEndToEndTests(300, params.STAGE, BUILD_URL)
+          tdr.runEndToEndTests(0, params.STAGE, BUILD_URL)
         }
       }
     }


### PR DESCRIPTION
The Jenkinsfile-update script just calls the Keycloak API, so changes are applied immediately. There's no need to wait for a few minutes before running the end-to-end tests like we do in some Jenkinsfiles, because we don't need to wait for the ECS service to be restarted.