### PR TITLE
Login page accessibility fixes

### DIFF
--- a/themes/tdr/login/login-update-password.ftl
+++ b/themes/tdr/login/login-update-password.ftl
@@ -6,23 +6,30 @@
         ${updatePasswordPageTitle}
     <#elseif section = "form">
         <form id="kc-passwd-update-form" class="${properties.kcFormClass!}" action="${url.loginAction}" method="post">
-
-            <div class="govuk-form-group">
+            <div class="govuk-form-group<#if message?has_content && message.type = 'error'>--error</#if>">
+              <div class="govuk-form-group">
                 <h1 class="govuk-label-wrapper">
-                    <label for="password-new" class="govuk-label govuk-label--l">${msg("passwordNew")}</label>
+                  <label for="password-new" class="govuk-label govuk-label--l">${msg("passwordNew")}</label>
                 </h1>
                 <div id="password-new-hint" class="govuk-hint">
                     ${msg("passwordRestrictions")}
                 </div>
                 <input type="password" id="password-new" name="password-new" class="govuk-input govuk-!-width-one-half" autofocus autocomplete="new-password" />
-            </div>
+              </div>
 
-            <div class="govuk-form-group">
+              <div class="govuk-form-group">
                 <h1 class="govuk-label-wrapper">
-                    <label for="password-confirm" class="govuk-label govuk-label--l">${msg("passwordConfirm")}</label>
+                  <label for="password-confirm" class="govuk-label govuk-label--l">${msg("passwordConfirm")}</label>
                 </h1>
                 <input type="password" id="password-confirm" name="password-confirm" class="govuk-input govuk-!-width-one-half" autocomplete="new-password" />
+              </div>
             </div>
+            <#if message?has_content && message.type = 'error'>
+                <span class="govuk-error-message" id="error-kc-form-login">
+                  <span class="govuk-visually-hidden">${msg("screenReaderError")}</span>
+                  ${message.summary}
+                </span>
+            </#if>
 
             <button class="govuk-button" type="submit" data-module="govuk-button" role="button">
                 ${msg("doSubmit")}

--- a/themes/tdr/login/login.ftl
+++ b/themes/tdr/login/login.ftl
@@ -4,29 +4,42 @@
         ${msg("doLogIn")}
     <#elseif section = "form">
         <#if realm.password>
-            <form id="kc-form-login" onsubmit="login.disabled = true; return true;" action="${url.loginAction}" method="post">
-                <div class="govuk-form-group">
-                    <h1 class="govuk-label-wrapper">
-                        <label for="username" class="govuk-label govuk-label--l">
-                            ${msg("email")}
-                        </label>
-                    </h1>
-                    <input tabindex="1" id="username" class="govuk-input govuk-!-width-one-half" name="username" value="${(login.username!'')}"  type="text" autofocus autocomplete="off" />
-                </div>
+          <form id="kc-form-login" onsubmit="login.disabled = true; return true;" action="${url.loginAction}"
+                method="post">
+            <div class="govuk-form-group<#if message?has_content>--error</#if>">
+              <div class="govuk-form-group">
+                <h1 class="govuk-label-wrapper">
+                  <label for="username" class="govuk-label govuk-label--l">
+                      ${msg("email")}
+                  </label>
+                </h1>
+                <input id="username" class="govuk-input govuk-!-width-one-half" name="username"
+                       value="${(login.username!'')}" type="text" autofocus autocomplete="off"/>
+              </div>
+              <div class="govuk-form-group">
+                <h1 class="govuk-label-wrapper">
+                  <label for="password" class="govuk-label govuk-label--l">${msg("password")}</label>
+                </h1>
+                <input id="password" class="govuk-input govuk-!-width-one-half" name="password" type="password"
+                       autocomplete="off"/>
+              </div>
+            </div>
 
-                <div class="govuk-form-group">
-                    <h1 class="govuk-label-wrapper">
-                        <label for="password" class="govuk-label govuk-label--l">${msg("password")}</label>
-                    </h1>
-                    <input tabindex="2" id="password" class="govuk-input govuk-!-width-one-half" name="password" type="password" autocomplete="off" />
-                </div>
+              <#if message?has_content>
+                <span class="govuk-error-message" id="error-kc-form-login">
+                  <span class="govuk-visually-hidden">${msg("screenReaderError")}</span>
+                  ${message.summary}
+                </span>
+              </#if>
 
-                <input type="hidden" id="id-hidden-input" name="credentialId" <#if auth.selectedCredential?has_content>value="${auth.selectedCredential}"</#if>/>
+            <input type="hidden" id="id-hidden-input" name="credentialId"
+                   <#if auth.selectedCredential?has_content>value="${auth.selectedCredential}"</#if>/>
 
-                <button class="govuk-button" type="submit" data-module="govuk-button" role="button" name="login">
-                    ${msg("continueButton")}
-                </button>
-            </form>
+
+            <button class="govuk-button" type="submit" data-module="govuk-button" role="button" name="login">
+                ${msg("continueButton")}
+            </button>
+          </form>
         </#if>
     </#if>
 </@layout.registrationLayout>

--- a/themes/tdr/login/messages/messages_en.properties
+++ b/themes/tdr/login/messages/messages_en.properties
@@ -6,3 +6,4 @@ mainHeader=Transfer Digital Records
 passwordNew=New password
 passwordRestrictions=Password must be at least 10 characters
 updatePasswordTitle=Set new password
+screenReaderError=Error:

--- a/themes/tdr/login/template.ftl
+++ b/themes/tdr/login/template.ftl
@@ -1,7 +1,7 @@
 <#assign signInPageTitle = msg("loginTitle")>
 
 <#macro registrationLayout pageTitle=signInPageTitle displayMessage=true>
-    <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"  "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+    <!DOCTYPE html>
     <html xmlns="http://www.w3.org/1999/xhtml" lang="en">
         <head>
             <meta charset="utf-8">
@@ -65,13 +65,15 @@
                             <#-- Start TDR Error Messages -->
                             <#if displayMessage && message?has_content>
                                 <#if message.type = 'error'>
-                                    <div class="govuk-error-summary" role="group" aria-labelledby="error-summary-heading" role="alert" tabindex="-1" data-module="govuk-error-summary">
+                                    <div class="govuk-error-summary" aria-labelledby="error-summary-heading" role="alert" tabindex="-1" data-module="govuk-error-summary">
                                         <h2 class="govuk-error-summary__title" id="error-summary-title">
                                             There is a problem with this form
                                         </h2>
                                         <div class="govuk-error-summary__body">
                                             <ul class="govuk-list govuk-error-summary__list">
-                                                <li>${message.summary}</li>
+                                                <li>
+                                                    <a href="#error-kc-form-login">${message.summary}</a>
+                                                </li>
                                             </ul>
                                         </div>
                                     </div>


### PR DESCRIPTION
- Template fixes 
Change the doctype as recommended by lighthouse 
Remove redundant group role 
Change the error message to a link to the form error.

- Login page fixes 
Remove explicit tabindex on both input boxes 
Add the form error message to match our other pages.

- Add error prefix to messages files
