### PR TITLE
Remove colours from logging.

### DIFF
--- a/standalone-ha.xml
+++ b/standalone-ha.xml
@@ -85,7 +85,7 @@
         <subsystem xmlns="urn:jboss:domain:logging:7.0">
             <console-handler name="CONSOLE">
                 <formatter>
-                    <named-formatter name="COLOR-PATTERN"/>
+                    <named-formatter name="PATTERN"/>
                 </formatter>
             </console-handler>
             <logger category="com.arjuna">
@@ -111,9 +111,6 @@
             </root-logger>
             <formatter name="PATTERN">
                 <pattern-formatter pattern="%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n"/>
-            </formatter>
-            <formatter name="COLOR-PATTERN">
-                <pattern-formatter pattern="%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n"/>
             </formatter>
         </subsystem>
         <subsystem xmlns="urn:jboss:domain:bean-validation:1.0"/>


### PR DESCRIPTION
Without the colours, which you can't see in cloudwatch anyway, the formatter set in this PR https://github.com/nationalarchives/tdr-terraform-environments/pull/111 will work and we get stack traces in a single event.
