### PR TITLE
Change date format to use dot instead of comma for milliseconds

### DIFF
--- a/standalone-ha.xml
+++ b/standalone-ha.xml
@@ -110,7 +110,7 @@
                 </handlers>
             </root-logger>
             <formatter name="PATTERN">
-                <pattern-formatter pattern="%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n"/>
+                <pattern-formatter pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p [%c] (%t) %s%e%n"/>
             </formatter>
         </subsystem>
         <subsystem xmlns="urn:jboss:domain:bean-validation:1.0"/>


### PR DESCRIPTION
The date format has been changed because we're trying to sort out multiline logging using https://docs.docker.com/config/containers/logging/awslogs/#awslogs-datetime-format
The problem is that the millisecond option %L matches to .123 with the mandatory leading dot and there's no way to get the format to accept ,123
There's a github issue here https://github.com/moby/moby/issues/36796 which doesn't have any recent activity so the only way to use this is to change the format to use a dot instead of the default comma.
