### PR TITLE
Add create user script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ COPY environment-properties /tmp/environment-properties
 COPY import_tdr_realm.py update_client_configuration.py update_realm_configuration.py tdr-realm-export.json /tmp/
 COPY standalone-ha.xml /opt/jboss/keycloak/standalone/configuration/
 COPY themes/tdr/login /opt/jboss/keycloak/themes/tdr/login
+COPY create-users.sh /tmp/create-users.sh
+COPY tdr-configurations/keycloak/run-create-users.sh /opt/jboss/startup-scripts/run-create-users.sh
 RUN chown -R jboss /tmp/environment-properties
 RUN chown jboss /tmp/tdr-realm-export.json /tmp/import_tdr_realm.py
 RUN chmod +x /tmp/import_tdr_realm.py

--- a/create-users.sh
+++ b/create-users.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+i=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8080)
+
+while [ $i -ne 200 ]
+  do
+  i=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8080)
+  sleep 2
+done
+
+cd /opt/jboss/keycloak/bin/
+./kcadm.sh config credentials --server http://localhost:8080/auth --realm master --user $KEYCLOAK_USER --password $KEYCLOAK_PASSWORD
+./kcadm.sh create users -s username=$2 -s enabled=true -r master  -s email=$1
+curl https://stedolan.github.io/jq/download/linux64/jq > jq
+chmod +x jq
+USER_ID=$(./kcadm.sh get users -r master -q email=$1 --fields id | ./jq -r '.[0]'.id)
+
+# This next line is for demo purposes and shouldn't be included in the final script
+./kcadm.sh update realms/master -f /tmp/realm.json
+
+./kcadm.sh update users/$USER_ID/execute-actions-email --body '["UPDATE_PASSWORD", "CONFIGURE_TOTP"]'
+
+# We can configure which roles are needed for users
+./kcadm.sh add-roles -r master --uusername $2  --rolename admin
+ADMIN_USER=$(./kcadm.sh get users -r master -q username=$KEYCLOAK_USER --fields id | ./jq -r '.[0]'.id)
+rm jq
+
+# We can control whether the admin is deleted like this with environment variables
+# Or we could have a PR to comment out this line if we need to create the admin user
+if [ $DELETE_ADMIN_USER == "true" ]
+then
+  ./kcadm.sh delete users/$ADMIN_USER -r master
+fi
+

--- a/create-users.sh
+++ b/create-users.sh
@@ -15,9 +15,6 @@ curl https://stedolan.github.io/jq/download/linux64/jq > jq
 chmod +x jq
 USER_ID=$(./kcadm.sh get users -r master -q email=$1 --fields id | ./jq -r '.[0]'.id)
 
-# This next line is for demo purposes and shouldn't be included in the final script
-./kcadm.sh update realms/master -f /tmp/realm.json
-
 ./kcadm.sh update users/$USER_ID/execute-actions-email --body '["UPDATE_PASSWORD", "CONFIGURE_TOTP"]'
 
 # We can configure which roles are needed for users


### PR DESCRIPTION
This script creates named admin users for the devs in keycloak and
deletes the initial admin user.

The steps are

* Login with the admin credentials provided in the environment variables
* Wait for the server to start. This script is run in a background process so it doesn't hold up the main startup script
* Create the user without a password or any other way to login
* Add the admin realm role to the user
* Send an email getting the user to set up 2FA and set a password.
* Delete the admin user. This is currently controlled by an environment variable but we could change it if we want a different way to create an admin user in an emergency.
