### PR TITLE
Remove GDS transport font

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,8 @@
   "private": true,
   "scripts": {
     "copy-govuk-image-assets": "copyfiles -f node_modules/govuk-frontend/govuk/assets/images/* ./themes/tdr/$npm_config_theme/resources/img -e node_modules/govuk-frontend/govuk/assets/images/favicon*",
-    "copy-govuk-font-assets": "copyfiles -f node_modules/govuk-frontend/govuk/assets/fonts/* ./themes/tdr/$npm_config_theme/resources/fonts",
     "copy-govuk-js-assets": "copyfiles -f node_modules/govuk-frontend/govuk/all.js ./themes/tdr/$npm_config_theme/resources/js",
-    "copy-assets": "npm-run-all copy-govuk-image-assets copy-govuk-font-assets copy-govuk-js-assets",
+    "copy-assets": "npm-run-all copy-govuk-image-assets copy-govuk-js-assets",
     "sass-compile": "node-sass ./themes/tdr/css-src/sass/main.scss ./themes/tdr/css-src/main.css",
     "add-stylesheet-dir": "mkdir -p ./themes/tdr/$npm_config_theme/resources/css",
     "compress-css": "minify ./themes/tdr/css-src/main.css > ./themes/tdr/$npm_config_theme/resources/css/main.css",

--- a/themes/tdr/css-src/sass/main.scss
+++ b/themes/tdr/css-src/sass/main.scss
@@ -2,7 +2,7 @@
 $govuk-images-path: '../img/';
 $govuk-fonts-path: '../fonts/';
 
-@import 'node_modules/govuk-frontend/govuk/all';
-
 @import 'overrides/all';
+
+@import 'node_modules/govuk-frontend/govuk/all';
 @import 'header';

--- a/themes/tdr/css-src/sass/overrides/_typography.scss
+++ b/themes/tdr/css-src/sass/overrides/_typography.scss
@@ -4,3 +4,5 @@
 body {
   font-family: Arial, sans-serif;
 }
+
+$govuk-font-family: Arial, sans-serif;


### PR DESCRIPTION
- Don't copy GDS font to the resources directory.
- Override the govuk font family.
- Move the override import above the gov uk import.
