### PR TITLE
Remove bintray for govuk-notify libraries

### DIFF
--- a/govuk-notify-spi/build.sbt
+++ b/govuk-notify-spi/build.sbt
@@ -2,16 +2,9 @@ import Dependencies._
 
 scalaVersion := "2.13.4"
 
-lazy val commonSettings = Seq(
-  resolvers ++= Seq[Resolver](
-    "notify-java-client" at "https://dl.bintray.com/gov-uk-notify/maven/"
-  )
-)
-
 lazy val root = (project in file("."))
   .settings(
     name := "govuk-notify-spi",
-    commonSettings,
     scalaVersion := "2.13.4",
     libraryDependencies ++= Seq(
       keycloakCore,

--- a/govuk-notify-spi/project/plugins.sbt
+++ b/govuk-notify-spi/project/plugins.sbt
@@ -1,3 +1,2 @@
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.15.0")
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
-resolvers += Resolver.jcenterRepo


### PR DESCRIPTION
Bintray is to be retired and govuk-notify client libraries are moved to maven central instead