### PR TITLE
Update TOTP errors.

### DIFF
--- a/themes/tdr/login/login-otp.ftl
+++ b/themes/tdr/login/login-otp.ftl
@@ -9,8 +9,17 @@
                     <label class="govuk-label" for="otp">
                         ${msg("loginOtpOneTime")}
                     </label>
+                    <div id="otp-hint" class="govuk-hint">
+                      ${msg("loginTotpHint")}
+                    </div>
                     <input id="otp" name="otp" autocomplete="off" type="text" class="govuk-input govuk-!-width-two-thirds"
                            autofocus/>
+                    <#if message?has_content>
+                      <span class="govuk-error-message" id="error-kc-form-login">
+                        <span class="govuk-visually-hidden">${msg("screenReaderError")}</span>
+                        ${message.summary}
+                      </span>
+                    </#if>
                 </div>
             </div>
 

--- a/themes/tdr/login/messages/messages_en.properties
+++ b/themes/tdr/login/messages/messages_en.properties
@@ -6,6 +6,7 @@ betaBannerLink=get in touch (opens in new tab).
 doLogIn=Sign in
 expiredActionMessage=The link has already been used.
 expiredActionTokenNoSessionMessage=The link has expired.
+loginTotpHint=For example, ''123456'' without any spaces.
 loginTotpStep2=Open the application and scan the QR code:
 loginTitle=Sign in to your account
 loginTotpScanBarcode=I want to scan a QR code instead
@@ -17,6 +18,7 @@ passwordRestrictions=Password must be at least 10 characters
 resetPassword=I need to reset my password
 screenReaderError=Error:
 signInButton=Sign in
+totpErrorContact=If the code has been entered correctly and the problem continues, contact <a href="mailto:tdr@nationalarchives.gov.uk">tdr@nationalarchives.gov.uk</a>.
 updatePasswordTitle=Set new password
-invalidTotpMessage=Invalid authenticator code. The authentication code should be entered without any spaces.
+invalidTotpMessage=Enter a one time code in the correct format.
 email=Email address

--- a/themes/tdr/login/template.ftl
+++ b/themes/tdr/login/template.ftl
@@ -79,7 +79,7 @@
                     <#-- Start TDR Error Messages -->
                     <#if displayMessage && message?has_content>
                         <#if message.type = 'error'>
-                            <div class="govuk-error-summary" aria-labelledby="error-summary-heading" role="alert"
+                            <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert"
                                  tabindex="-1" data-module="govuk-error-summary">
                                 <h2 class="govuk-error-summary__title" id="error-summary-title">
                                     There is a problem with this form

--- a/themes/tdr/login/template.ftl
+++ b/themes/tdr/login/template.ftl
@@ -90,6 +90,9 @@
                                             <a href="#error-kc-form-login">${message.summary}</a>
                                         </li>
                                     </ul>
+                                    <#if message.summary = msg("invalidTotpMessage")>
+                                        <p>${msg("totpErrorContact")?no_esc}</p>
+                                    </#if>
                                 </div>
                             </div>
                         <#else>


### PR DESCRIPTION
There are a couple of changes here.
* Update the error message to match the new designs.
* Add an error field to the TOTP input as this wasn't there already.
* Add the message to contact us to the error div inside template.ftl. We don't want to display this for other login related errors so we're now checking if the error message matches the TOTP one and displaying the contact us message if it is.
