### PR TITLE
Change span to paragraph tags for error messages.

### DIFF
--- a/themes/tdr/login/login-config-totp.ftl
+++ b/themes/tdr/login/login-config-totp.ftl
@@ -63,10 +63,10 @@
                         <#if mode??><input type="hidden" id="mode" name="mode" value="${mode}"/></#if>
                     </div>
                     <#if message?has_content && message.type = 'error'>
-                      <span class="govuk-error-message" id="error-form-login">
+                      <p class="govuk-error-message" id="error-form-login">
                         <span class="govuk-visually-hidden">${msg("screenReaderError")}</span>
                         ${message.summary}
-                      </span>
+                      </p>
                     </#if>
                     <button class="govuk-button" type="submit" data-module="govuk-button" role="button" name="login">
                         ${msg("doSubmit")}

--- a/themes/tdr/login/login-otp.ftl
+++ b/themes/tdr/login/login-otp.ftl
@@ -15,10 +15,10 @@
                     <input id="otp" name="otp" autocomplete="off" type="text" class="govuk-input govuk-!-width-two-thirds"
                            autofocus/>
                     <#if message?has_content>
-                      <span class="govuk-error-message" id="error-kc-form-login">
+                      <p class="govuk-error-message" id="error-kc-form-login">
                         <span class="govuk-visually-hidden">${msg("screenReaderError")}</span>
                         ${message.summary}
-                      </span>
+                      </p>
                     </#if>
                 </div>
             </div>

--- a/themes/tdr/login/login-update-password.ftl
+++ b/themes/tdr/login/login-update-password.ftl
@@ -25,10 +25,10 @@
               </div>
             </div>
             <#if message?has_content && message.type = 'error'>
-                <span class="govuk-error-message" id="error-kc-form-login">
+                <p class="govuk-error-message" id="error-kc-form-login">
                   <span class="govuk-visually-hidden">${msg("screenReaderError")}</span>
                   ${message.summary}
-                </span>
+                </p>
             </#if>
 
             <button class="govuk-button" type="submit" data-module="govuk-button" role="button">

--- a/themes/tdr/login/login.ftl
+++ b/themes/tdr/login/login.ftl
@@ -24,10 +24,10 @@
             </div>
 
               <#if message?has_content>
-                <span class="govuk-error-message" id="error-kc-form-login">
+                <p class="govuk-error-message" id="error-kc-form-login">
                   <span class="govuk-visually-hidden">${msg("screenReaderError")}</span>
                   ${message.summary}
-                </span>
+                </p>
               </#if>
 
             <input type="hidden" id="id-hidden-input" name="credentialId"


### PR DESCRIPTION
The upgrade to v4.0.0 of the gov uk frontend was done a month back by dependabot but the release notes recommend replacing `<span>` for `<p>` for error messages.
