### PR TITLE
Add a task to monitor for users missing MFA

### DIFF
--- a/event-publisher-spi/src/main/scala/uk/gov/nationalarchives/eventpublisherspi/EventPublisherProviderFactory.scala
+++ b/event-publisher-spi/src/main/scala/uk/gov/nationalarchives/eventpublisherspi/EventPublisherProviderFactory.scala
@@ -12,6 +12,8 @@ class EventPublisherProviderFactory extends EventListenerProviderFactory {
 
   var eventPublisherConfig: Option[EventPublisherConfig] = None
 
+  var oneDayIntervalMillis: Long = 24 * 60 * 60 * 1000
+
   override def create(session: KeycloakSession): EventListenerProvider = {
     EventPublisherProvider(eventPublisherConfig.get, session);
   }
@@ -26,10 +28,10 @@ class EventPublisherProviderFactory extends EventListenerProviderFactory {
   override def postInit(factory: KeycloakSessionFactory): Unit = {
     factory.register(event => {
       if(event.isInstanceOf[PostMigrationEvent]) {
-         val session = factory.create()
+        val session = factory.create()
         val provider: TimerProvider = session.getProvider(classOf[TimerProvider])
-        val task = UserMonitoringTask(eventPublisherConfig.get)
-        provider.scheduleTask(task, 24 * 60 * 60 * 1000, "test")
+        val userMonitoringTask = UserMonitoringTask(eventPublisherConfig.get)
+        provider.scheduleTask(userMonitoringTask, oneDayIntervalMillis, "userMonitoringTask")
       }
     })
   }

--- a/event-publisher-spi/src/main/scala/uk/gov/nationalarchives/eventpublisherspi/UserMonitoringTask.scala
+++ b/event-publisher-spi/src/main/scala/uk/gov/nationalarchives/eventpublisherspi/UserMonitoringTask.scala
@@ -48,8 +48,11 @@ class UserMonitoringTask(snsUtils: SNSUtils, config: EventPublisherConfig, crede
     })
   }
 }
+
 object UserMonitoringTask {
   private val httpClient = ApacheHttpClient.builder.build
+
+  private val credentialType = "otp"
 
   def apply(config: EventPublisherConfig): UserMonitoringTask = {
     val snsUtils: SNSUtils = SNSUtils(SnsClient.builder()
@@ -57,6 +60,6 @@ object UserMonitoringTask {
       .endpointOverride(URI.create(config.sqsUrl))
       .httpClient(httpClient)
       .build())
-    new UserMonitoringTask(snsUtils, config, "otp")
+    new UserMonitoringTask(snsUtils, config, credentialType)
   }
 }

--- a/event-publisher-spi/src/main/scala/uk/gov/nationalarchives/eventpublisherspi/UserMonitoringTask.scala
+++ b/event-publisher-spi/src/main/scala/uk/gov/nationalarchives/eventpublisherspi/UserMonitoringTask.scala
@@ -1,0 +1,62 @@
+package uk.gov.nationalarchives.eventpublisherspi
+
+import org.jboss.logging.Logger
+import org.keycloak.models.{KeycloakSession, UserModel, UserProvider}
+import org.keycloak.timer.ScheduledTask
+import software.amazon.awssdk.http.apache.ApacheHttpClient
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.sns.SnsClient
+import uk.gov.nationalarchives.aws.utils.SNSUtils
+import uk.gov.nationalarchives.eventpublisherspi.EventPublisherProvider.{EventDetails, EventPublisherConfig}
+import io.circe.generic.auto._
+import io.circe.syntax.EncoderOps
+import java.net.URI
+import scala.jdk.CollectionConverters._
+
+class UserMonitoringTask(snsUtils: SNSUtils, config: EventPublisherConfig, credentialType: String) extends ScheduledTask {
+  val logger: Logger = Logger.getLogger(classOf[UserMonitoringTask])
+
+  override def run(session: KeycloakSession): Unit = {
+    val userProvider: UserProvider =  session.users()
+    val realms = session.realms()
+      .getRealmsStream.iterator().asScala.toList
+    realms.foreach(realm => {
+      val credentialManager = session.userCredentialManager()
+      val users: List[UserModel] = userProvider.getUsersStream(realm).iterator().asScala.toList
+      val usersNoMFA = users
+        .filter(u => {
+          !credentialManager.isConfiguredFor(realm, u, credentialType)
+        })
+      val userIds = usersNoMFA.map(_.getId)
+      val realmName = realm.getName
+      if(usersNoMFA.nonEmpty) {
+        val suffix = if(usersNoMFA.size == 1) "" else "s"
+        val message =
+          s"""
+             |$realmName realm has ${usersNoMFA.size} user$suffix without MFA
+             |${userIds.take(10).mkString("\n")}
+             |""".stripMargin
+        logger.info(
+          s"""
+             |The following users have missing MFA in realm $realmName
+             |${userIds.mkString("\n")}
+             |""".stripMargin)
+
+        val eventDetails = EventDetails(config.tdrEnvironment, message).asJson.toString()
+        snsUtils.publish(eventDetails, config.snsTopicArn)
+      }
+    })
+  }
+}
+object UserMonitoringTask {
+  private val httpClient = ApacheHttpClient.builder.build
+
+  def apply(config: EventPublisherConfig): UserMonitoringTask = {
+    val snsUtils: SNSUtils = SNSUtils(SnsClient.builder()
+      .region(Region.EU_WEST_2)
+      .endpointOverride(URI.create(config.sqsUrl))
+      .httpClient(httpClient)
+      .build())
+    new UserMonitoringTask(snsUtils, config, "otp")
+  }
+}

--- a/event-publisher-spi/src/test/scala/uk.gov.nationalarchives.eventpublisherspi/UserMonitoringTaskSpec.scala
+++ b/event-publisher-spi/src/test/scala/uk.gov.nationalarchives.eventpublisherspi/UserMonitoringTaskSpec.scala
@@ -1,0 +1,141 @@
+package uk.gov.nationalarchives.eventpublisherspi
+
+import org.keycloak.models._
+import org.mockito.MockitoSugar
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import uk.gov.nationalarchives.aws.utils.SNSUtils
+import uk.gov.nationalarchives.eventpublisherspi.EventPublisherProvider.EventPublisherConfig
+
+class UserMonitoringTaskSpec extends AnyFlatSpec with Matchers with MockitoSugar {
+  "The run method" should "not send a message if there are no users missing MFA" in {
+    val mockSession = mock[KeycloakSession]
+    val mockRealmProvider = mock[RealmProvider]
+    val mockRealmModel = mock[RealmModel]
+    val mockUserCredentialManager = mock[UserCredentialManager]
+    val mockUserModel = mock[UserModel]
+    val mockUserProvider = mock[UserProvider]
+    val mockSnsUtils = mock[SNSUtils]
+    val credentialType = "otp"
+
+    when(mockRealmModel.getName).thenReturn("testRealm")
+    when(mockUserProvider.getUsersStream(mockRealmModel)).thenReturn(java.util.stream.Stream.of(mockUserModel))
+    when(mockUserCredentialManager.isConfiguredFor(mockRealmModel, mockUserModel, credentialType)).thenReturn(true)
+    when(mockRealmProvider.getRealmsStream).thenReturn(java.util.stream.Stream.of(mockRealmModel))
+    when(mockSession.users()).thenReturn(mockUserProvider)
+    when(mockSession.realms()).thenReturn(mockRealmProvider)
+    when(mockSession.userCredentialManager()).thenReturn(mockUserCredentialManager)
+    new UserMonitoringTask(mockSnsUtils, EventPublisherConfig("https://example.com", "", "test"), credentialType).run(mockSession)
+
+    verifyZeroInteractions(mockSnsUtils)
+  }
+
+  "The run method" should "send a message if there is one user with MFA and one without" in {
+    val mockSession = mock[KeycloakSession]
+    val mockRealmProvider = mock[RealmProvider]
+    val mockRealmModel = mock[RealmModel]
+    val mockUserCredentialManager = mock[UserCredentialManager]
+    val mockUserModelWithMFA = mock[UserModel]
+    val mockUserModelWithoutMFA = mock[UserModel]
+    val mockUserProvider = mock[UserProvider]
+    val mockSnsUtils = mock[SNSUtils]
+    val userId = "dfd7356c-e6e0-40dd-affd-de04e29ad359"
+    val topicArn = "snsTopicArn"
+    val credentialType = "otp"
+
+    when(mockRealmModel.getName).thenReturn("testRealm")
+    when(mockUserModelWithoutMFA.getId).thenReturn(userId)
+    when(mockUserProvider.getUsersStream(mockRealmModel)).thenReturn(java.util.stream.Stream.of(mockUserModelWithMFA, mockUserModelWithoutMFA))
+    when(mockUserCredentialManager.isConfiguredFor(mockRealmModel, mockUserModelWithMFA, credentialType)).thenReturn(true)
+    when(mockUserCredentialManager.isConfiguredFor(mockRealmModel, mockUserModelWithoutMFA, credentialType)).thenReturn(false)
+    when(mockRealmProvider.getRealmsStream).thenReturn(java.util.stream.Stream.of(mockRealmModel))
+    when(mockSession.users()).thenReturn(mockUserProvider)
+    when(mockSession.realms()).thenReturn(mockRealmProvider)
+    when(mockSession.userCredentialManager()).thenReturn(mockUserCredentialManager)
+    new UserMonitoringTask(mockSnsUtils, EventPublisherConfig("https://example.com", topicArn, "test"), credentialType).run(mockSession)
+
+    val expectedMessage = """{
+                             |  "tdrEnv" : "test",
+                             |  "message" : "\ntestRealm realm has 1 user without MFA\ndfd7356c-e6e0-40dd-affd-de04e29ad359\n"
+                             |}""".stripMargin
+
+    verify(mockSnsUtils, times(1)).publish(expectedMessage, topicArn)
+  }
+
+  "The run method" should "send a message if there are two users with MFA missing" in {
+    val mockSession = mock[KeycloakSession]
+    val mockRealmProvider = mock[RealmProvider]
+    val mockRealmModel = mock[RealmModel]
+    val mockUserCredentialManager = mock[UserCredentialManager]
+    val mockUserModelWithoutMFA1 = mock[UserModel]
+    val mockUserModelWithoutMFA2 = mock[UserModel]
+    val mockUserProvider = mock[UserProvider]
+    val mockSnsUtils = mock[SNSUtils]
+    val userId1 = "dfd7356c-e6e0-40dd-affd-de04e29ad359"
+    val userId2 = "4b3c3e89-775a-4c69-974e-bdc194a04d2d"
+    val topicArn = "snsTopicArn"
+    val credentialType = "otp"
+
+    when(mockRealmModel.getName).thenReturn("testRealm")
+    when(mockUserModelWithoutMFA1.getId).thenReturn(userId1)
+    when(mockUserModelWithoutMFA2.getId).thenReturn(userId2)
+    when(mockUserProvider.getUsersStream(mockRealmModel)).thenReturn(java.util.stream.Stream.of(mockUserModelWithoutMFA1, mockUserModelWithoutMFA2))
+    when(mockUserCredentialManager.isConfiguredFor(mockRealmModel, mockUserModelWithoutMFA1, credentialType)).thenReturn(false)
+    when(mockUserCredentialManager.isConfiguredFor(mockRealmModel, mockUserModelWithoutMFA2, credentialType)).thenReturn(false)
+    when(mockRealmProvider.getRealmsStream).thenReturn(java.util.stream.Stream.of(mockRealmModel))
+    when(mockSession.users()).thenReturn(mockUserProvider)
+    when(mockSession.realms()).thenReturn(mockRealmProvider)
+    when(mockSession.userCredentialManager()).thenReturn(mockUserCredentialManager)
+    new UserMonitoringTask(mockSnsUtils, EventPublisherConfig("https://example.com", topicArn, "test"), credentialType).run(mockSession)
+
+    val expectedMessage = """{
+                            |  "tdrEnv" : "test",
+                            |  "message" : "\ntestRealm realm has 2 users without MFA\ndfd7356c-e6e0-40dd-affd-de04e29ad359\n4b3c3e89-775a-4c69-974e-bdc194a04d2d\n"
+                            |}""".stripMargin
+
+    verify(mockSnsUtils, times(1)).publish(expectedMessage, topicArn)
+  }
+
+  "The run method" should "send a message if there are two users in two different realms with MFA missing" in {
+    val mockSession = mock[KeycloakSession]
+    val mockRealmProvider = mock[RealmProvider]
+    val mockRealmModel1 = mock[RealmModel]
+    val mockRealmModel2 = mock[RealmModel]
+    val mockUserCredentialManager = mock[UserCredentialManager]
+    val mockUserModelWithoutMFA1 = mock[UserModel]
+    val mockUserModelWithoutMFA2 = mock[UserModel]
+    val mockUserProvider = mock[UserProvider]
+    val mockSnsUtils = mock[SNSUtils]
+    val userId1 = "dfd7356c-e6e0-40dd-affd-de04e29ad359"
+    val userId2 = "4b3c3e89-775a-4c69-974e-bdc194a04d2d"
+    val topicArn = "snsTopicArn"
+    val credentialType = "otp"
+
+    when(mockRealmModel1.getName).thenReturn("testRealm1")
+    when(mockRealmModel2.getName).thenReturn("testRealm2")
+    when(mockUserModelWithoutMFA1.getId).thenReturn(userId1)
+    when(mockUserModelWithoutMFA2.getId).thenReturn(userId2)
+    when(mockUserProvider.getUsersStream(mockRealmModel1)).thenReturn(java.util.stream.Stream.of(mockUserModelWithoutMFA1))
+    when(mockUserProvider.getUsersStream(mockRealmModel2)).thenReturn(java.util.stream.Stream.of(mockUserModelWithoutMFA2))
+    when(mockUserCredentialManager.isConfiguredFor(mockRealmModel1, mockUserModelWithoutMFA1, credentialType)).thenReturn(false)
+    when(mockUserCredentialManager.isConfiguredFor(mockRealmModel2, mockUserModelWithoutMFA2, credentialType)).thenReturn(false)
+    when(mockRealmProvider.getRealmsStream).thenReturn(java.util.stream.Stream.of(mockRealmModel1, mockRealmModel2))
+    when(mockSession.users()).thenReturn(mockUserProvider)
+    when(mockSession.realms()).thenReturn(mockRealmProvider)
+    when(mockSession.userCredentialManager()).thenReturn(mockUserCredentialManager)
+    new UserMonitoringTask(mockSnsUtils, EventPublisherConfig("https://example.com", topicArn, "test"), credentialType).run(mockSession)
+
+    val expectedMessage1 = """{
+                            |  "tdrEnv" : "test",
+                            |  "message" : "\ntestRealm1 realm has 1 user without MFA\ndfd7356c-e6e0-40dd-affd-de04e29ad359\n"
+                            |}""".stripMargin
+
+    val expectedMessage2 = """{
+                            |  "tdrEnv" : "test",
+                            |  "message" : "\ntestRealm2 realm has 1 user without MFA\n4b3c3e89-775a-4c69-974e-bdc194a04d2d\n"
+                            |}""".stripMargin
+
+    verify(mockSnsUtils, times(1)).publish(expectedMessage1, topicArn)
+    verify(mockSnsUtils, times(1)).publish(expectedMessage2, topicArn)
+  }
+}

--- a/event-publisher-spi/src/test/scala/uk.gov.nationalarchives.eventpublisherspi/UserMonitoringTaskSpec.scala
+++ b/event-publisher-spi/src/test/scala/uk.gov.nationalarchives.eventpublisherspi/UserMonitoringTaskSpec.scala
@@ -8,6 +8,12 @@ import uk.gov.nationalarchives.aws.utils.SNSUtils
 import uk.gov.nationalarchives.eventpublisherspi.EventPublisherProvider.EventPublisherConfig
 
 class UserMonitoringTaskSpec extends AnyFlatSpec with Matchers with MockitoSugar {
+
+  val credentialType = "otp"
+  val userId = "dfd7356c-e6e0-40dd-affd-de04e29ad359"
+  val userId2 = "4b3c3e89-775a-4c69-974e-bdc194a04d2d"
+  val topicArn = "snsTopicArn"
+
   "The run method" should "not send a message if there are no users missing MFA" in {
     val mockSession = mock[KeycloakSession]
     val mockRealmProvider = mock[RealmProvider]
@@ -16,7 +22,6 @@ class UserMonitoringTaskSpec extends AnyFlatSpec with Matchers with MockitoSugar
     val mockUserModel = mock[UserModel]
     val mockUserProvider = mock[UserProvider]
     val mockSnsUtils = mock[SNSUtils]
-    val credentialType = "otp"
 
     when(mockRealmModel.getName).thenReturn("testRealm")
     when(mockUserProvider.getUsersStream(mockRealmModel)).thenReturn(java.util.stream.Stream.of(mockUserModel))
@@ -39,9 +44,6 @@ class UserMonitoringTaskSpec extends AnyFlatSpec with Matchers with MockitoSugar
     val mockUserModelWithoutMFA = mock[UserModel]
     val mockUserProvider = mock[UserProvider]
     val mockSnsUtils = mock[SNSUtils]
-    val userId = "dfd7356c-e6e0-40dd-affd-de04e29ad359"
-    val topicArn = "snsTopicArn"
-    val credentialType = "otp"
 
     when(mockRealmModel.getName).thenReturn("testRealm")
     when(mockUserModelWithoutMFA.getId).thenReturn(userId)
@@ -71,13 +73,9 @@ class UserMonitoringTaskSpec extends AnyFlatSpec with Matchers with MockitoSugar
     val mockUserModelWithoutMFA2 = mock[UserModel]
     val mockUserProvider = mock[UserProvider]
     val mockSnsUtils = mock[SNSUtils]
-    val userId1 = "dfd7356c-e6e0-40dd-affd-de04e29ad359"
-    val userId2 = "4b3c3e89-775a-4c69-974e-bdc194a04d2d"
-    val topicArn = "snsTopicArn"
-    val credentialType = "otp"
 
     when(mockRealmModel.getName).thenReturn("testRealm")
-    when(mockUserModelWithoutMFA1.getId).thenReturn(userId1)
+    when(mockUserModelWithoutMFA1.getId).thenReturn(userId)
     when(mockUserModelWithoutMFA2.getId).thenReturn(userId2)
     when(mockUserProvider.getUsersStream(mockRealmModel)).thenReturn(java.util.stream.Stream.of(mockUserModelWithoutMFA1, mockUserModelWithoutMFA2))
     when(mockUserCredentialManager.isConfiguredFor(mockRealmModel, mockUserModelWithoutMFA1, credentialType)).thenReturn(false)
@@ -106,14 +104,10 @@ class UserMonitoringTaskSpec extends AnyFlatSpec with Matchers with MockitoSugar
     val mockUserModelWithoutMFA2 = mock[UserModel]
     val mockUserProvider = mock[UserProvider]
     val mockSnsUtils = mock[SNSUtils]
-    val userId1 = "dfd7356c-e6e0-40dd-affd-de04e29ad359"
-    val userId2 = "4b3c3e89-775a-4c69-974e-bdc194a04d2d"
-    val topicArn = "snsTopicArn"
-    val credentialType = "otp"
 
     when(mockRealmModel1.getName).thenReturn("testRealm1")
     when(mockRealmModel2.getName).thenReturn("testRealm2")
-    when(mockUserModelWithoutMFA1.getId).thenReturn(userId1)
+    when(mockUserModelWithoutMFA1.getId).thenReturn(userId)
     when(mockUserModelWithoutMFA2.getId).thenReturn(userId2)
     when(mockUserProvider.getUsersStream(mockRealmModel1)).thenReturn(java.util.stream.Stream.of(mockUserModelWithoutMFA1))
     when(mockUserProvider.getUsersStream(mockRealmModel2)).thenReturn(java.util.stream.Stream.of(mockUserModelWithoutMFA2))


### PR DESCRIPTION
There is an existing scheduler within Keycloak which you can use. On the postInit method, we wait for the post migration event. I'm not completely sure why this event but it works. I got the idea from [this stackoverflow post](https://stackoverflow.com/questions/69656544/run-method-after-keycloak-server-startup)

We then create a new instance of the UserMonitoringTask which extends ScheduledTask and carries out the checks against the users for all realms.

If it finds users with no MFA, it sends a message to the notifications SNS topic.

