### PR TITLE
Don't use secrets in the build command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
       build-command: |
         npm install
         npm run build-theme
-        wget --header "Authorization: token ${{ secrets.WORKFLOW_PAT }}" https://raw.githubusercontent.com/nationalarchives/tdr-configurations/master/keycloak/tdr-realm-export.json
+        wget --header "Authorization: token $GITHUB_TOKEN" https://raw.githubusercontent.com/nationalarchives/tdr-configurations/master/keycloak/tdr-realm-export.json
         sbt assembly
     secrets:
       MANAGEMENT_ACCOUNT: ${{ secrets.MANAGEMENT_ACCOUNT }}


### PR DESCRIPTION
It turns out that you can't use a secret inside an input command like
this.
The secret is passed as an environment variable inside the re-usable
workflow so using normal environment variable syntax works here.

GitHub actions knows the environment variable is a secret and won't
print it.
