### PR TITLE
Remove 'device name' input from MFA config page

### DIFF
--- a/themes/tdr/login/login-config-totp.ftl
+++ b/themes/tdr/login/login-config-totp.ftl
@@ -52,7 +52,6 @@
             </#if>
             <li>
                 <p class="govuk-body">${msg("loginTotpStep3")}</p>
-                <p class="govuk-body">${msg("loginTotpStep3DeviceName")}</p>
                 <form action="${url.loginAction}" id="totp-settings-form" method="post">
                     <div class="govuk-form-group<#if message?has_content && message.type = 'error'>--error</#if>">
                         <label for="totp" class="govuk-label">${msg("authenticatorCode")}</label>

--- a/themes/tdr/login/login-config-totp.ftl
+++ b/themes/tdr/login/login-config-totp.ftl
@@ -58,8 +58,6 @@
                         <label for="totp" class="govuk-label">${msg("authenticatorCode")}</label>
                         <input type="text" id="totp" name="totp" autocomplete="off" class="govuk-input govuk-!-width-two-thirds" />
                         <input type="hidden" id="totpSecret" name="totpSecret" value="${totp.totpSecret}" />
-                        <label for="userLabel" class="govuk-label">${msg("loginTotpDeviceName")}</label>
-                        <input type="text" class="govuk-input govuk-!-width-two-thirds" id="userLabel" name="userLabel" autocomplete="off">
                         <#if mode??><input type="hidden" id="mode" name="mode" value="${mode}"/></#if>
                     </div>
                     <#if message?has_content && message.type = 'error'>

--- a/themes/tdr/login/messages/messages_en.properties
+++ b/themes/tdr/login/messages/messages_en.properties
@@ -15,7 +15,6 @@ loginTotpHint=For example, ''123456'' without any spaces.
 loginTotpStep2=Open the application and scan the QR code:
 loginTitle=Sign in to your account
 loginTotpScanBarcode=I want to scan a QR code instead
-loginTotpStep3DeviceName=Provide a device name to help you manage your OTP (One-time password) devices.
 loginTotpUnableToScan=I want to enter a key instead
 mainHeader=Transfer Digital Records
 passwordNew=New password


### PR DESCRIPTION
Causing user confusion when registering their account

Removing as is not required and was serving no purpose