### PR TITLE
Move google authenticator to the top of the list

### DIFF
--- a/themes/tdr/login/login-config-totp.ftl
+++ b/themes/tdr/login/login-config-totp.ftl
@@ -13,9 +13,9 @@
                 </label>
 
                 <ul id="supported-apps" class="govuk-list govuk-list--bullet">
+                    <li>Google Authenticator</li>
                     <li>Microsoft Authenticator</li>
                     <li>Free OTP</li>
-                    <li>Google Authenticator</li>
                 </ul>
             </li>
 


### PR DESCRIPTION
I will need to change the help page as well