### PR TITLE
Filter service account users from the MFA check.

### DIFF
--- a/event-publisher-spi/src/main/scala/uk/gov/nationalarchives/eventpublisherspi/UserMonitoringTask.scala
+++ b/event-publisher-spi/src/main/scala/uk/gov/nationalarchives/eventpublisherspi/UserMonitoringTask.scala
@@ -27,8 +27,9 @@ class UserMonitoringTask(snsClient: SnsClient,
     realms.foreach(realm => {
 
       val users: List[UserModel] = userProvider.searchForUserStream(realm, userSearchParams).iterator().asScala.toList
+
       val usersNoMFA = users
-        .filter(u => Option(u.getServiceAccountClientLink).nonEmpty && !u.getServiceAccountClientLink.isBlank)
+        .filter(u => Option(u.getServiceAccountClientLink).getOrElse("").isBlank)
         .filter(u => {
           val credentialManager: SubjectCredentialManager = u.credentialManager()
           validConfiguredCredentialTypes.forall(credentialType => !credentialManager.isConfiguredFor(credentialType))

--- a/event-publisher-spi/src/main/scala/uk/gov/nationalarchives/eventpublisherspi/UserMonitoringTask.scala
+++ b/event-publisher-spi/src/main/scala/uk/gov/nationalarchives/eventpublisherspi/UserMonitoringTask.scala
@@ -13,7 +13,11 @@ import uk.gov.nationalarchives.eventpublisherspi.EventPublisherProvider.{EventDe
 
 import scala.jdk.CollectionConverters._
 
-class UserMonitoringTask(snsClient: SnsClient, config: EventPublisherConfig, validConfiguredCredentialTypes: List[String], userSearchParams: java.util.Map[String, String]) extends ScheduledTask {
+class UserMonitoringTask(snsClient: SnsClient,
+                         config: EventPublisherConfig,
+                         validConfiguredCredentialTypes: List[String],
+                         userSearchParams: java.util.Map[String, String]) extends ScheduledTask {
+
   val logger: Logger = Logger.getLogger(classOf[UserMonitoringTask])
 
   override def run(session: KeycloakSession): Unit = {

--- a/event-publisher-spi/src/test/scala/uk.gov.nationalarchives.eventpublisherspi/UserMonitoringTaskSpec.scala
+++ b/event-publisher-spi/src/test/scala/uk.gov.nationalarchives.eventpublisherspi/UserMonitoringTaskSpec.scala
@@ -9,6 +9,7 @@ import software.amazon.awssdk.services.sns.model.PublishRequest
 import uk.gov.nationalarchives.eventpublisherspi.EventPublisherProvider.EventPublisherConfig
 
 import java.util
+import java.util.UUID
 import scala.jdk.CollectionConverters._
 class UserMonitoringTaskSpec extends AnyFlatSpec with Matchers with MockitoSugar {
 
@@ -56,6 +57,8 @@ class UserMonitoringTaskSpec extends AnyFlatSpec with Matchers with MockitoSugar
 
     when(mockRealmModel.getName).thenReturn("testRealm")
     when(mockUserModelWithoutMFA.getId).thenReturn(userId)
+    when(mockUserModelWithMFA.getServiceAccountClientLink).thenReturn(null)
+    when(mockUserModelWithoutMFA.getServiceAccountClientLink).thenReturn(null)
     when(mockUserProvider.searchForUserStream(mockRealmModel, searchMap)).thenReturn(java.util.stream.Stream.of(mockUserModelWithMFA, mockUserModelWithoutMFA))
     when(mockUserCredentialManagerWithMFA.isConfiguredFor(otpCredentialType)).thenReturn(true)
     when(mockUserCredentialManagerWithMFA.isConfiguredFor(webauthnCredentialType)).thenReturn(true)
@@ -208,7 +211,7 @@ class UserMonitoringTaskSpec extends AnyFlatSpec with Matchers with MockitoSugar
     when(mockRealmProvider.getRealmsStream).thenReturn(java.util.stream.Stream.of(mockRealmModel))
     when(mockSession.users()).thenReturn(mockUserProvider)
     when(mockSession.realms()).thenReturn(mockRealmProvider)
-    when(mockUserModel.getServiceAccountClientLink).thenReturn(null)
+    when(mockUserModel.getServiceAccountClientLink).thenReturn(UUID.randomUUID().toString)
     new UserMonitoringTask(mockSnsClient, EventPublisherConfig("", "test"), validConfiguredCredentialTypes, searchMap).run(mockSession)
 
     verifyZeroInteractions(mockSnsClient)

--- a/event-publisher-spi/src/test/scala/uk.gov.nationalarchives.eventpublisherspi/UserMonitoringTaskSpec.scala
+++ b/event-publisher-spi/src/test/scala/uk.gov.nationalarchives.eventpublisherspi/UserMonitoringTaskSpec.scala
@@ -195,7 +195,7 @@ class UserMonitoringTaskSpec extends AnyFlatSpec with Matchers with MockitoSugar
     verifyZeroInteractions(mockSnsClient)
   }
 
-  "The run method" should "not send a message if only service account methods are missing MFA" in {
+  "The run method" should "not send a message if only service account users are missing MFA" in {
     val mockSession = mock[KeycloakSession]
     val mockRealmProvider = mock[RealmProvider]
     val mockRealmModel = mock[RealmModel]

--- a/event-publisher-spi/src/test/scala/uk.gov.nationalarchives.eventpublisherspi/UserMonitoringTaskSpec.scala
+++ b/event-publisher-spi/src/test/scala/uk.gov.nationalarchives.eventpublisherspi/UserMonitoringTaskSpec.scala
@@ -8,8 +8,8 @@ import software.amazon.awssdk.services.sns.SnsClient
 import software.amazon.awssdk.services.sns.model.PublishRequest
 import uk.gov.nationalarchives.eventpublisherspi.EventPublisherProvider.EventPublisherConfig
 
-import scala.jdk.CollectionConverters.CollectionHasAsScala
-
+import java.util
+import scala.jdk.CollectionConverters._
 class UserMonitoringTaskSpec extends AnyFlatSpec with Matchers with MockitoSugar {
 
   val validConfiguredCredentialTypes: List[String] = List("otp", "webauthn")
@@ -18,6 +18,7 @@ class UserMonitoringTaskSpec extends AnyFlatSpec with Matchers with MockitoSugar
   val userId = "dfd7356c-e6e0-40dd-affd-de04e29ad359"
   val userId2 = "4b3c3e89-775a-4c69-974e-bdc194a04d2d"
   val topicArn = "snsTopicArn"
+  val searchMap: util.Map[String, String] = Map[String, String]().asJava
 
   "The run method" should "not send a message if there are no users missing MFA" in {
     val mockSession = mock[KeycloakSession]
@@ -29,14 +30,14 @@ class UserMonitoringTaskSpec extends AnyFlatSpec with Matchers with MockitoSugar
     val mockSnsClient = Mockito.mock(classOf[SnsClient])
 
     when(mockRealmModel.getName).thenReturn("testRealm")
-    when(mockUserProvider.getUsersStream(mockRealmModel)).thenReturn(java.util.stream.Stream.of(mockUserModel))
+    when(mockUserProvider.searchForUserStream(mockRealmModel, searchMap)).thenReturn(java.util.stream.Stream.of(mockUserModel))
     when(mockUserCredentialManager.isConfiguredFor(otpCredentialType)).thenReturn(true)
     when(mockUserCredentialManager.isConfiguredFor(webauthnCredentialType)).thenReturn(true)
     when(mockRealmProvider.getRealmsStream).thenReturn(java.util.stream.Stream.of(mockRealmModel))
     when(mockSession.users()).thenReturn(mockUserProvider)
     when(mockSession.realms()).thenReturn(mockRealmProvider)
     when(mockUserModel.credentialManager()).thenReturn(mockUserCredentialManager)
-    new UserMonitoringTask(mockSnsClient, EventPublisherConfig("", "test"), validConfiguredCredentialTypes).run(mockSession)
+    new UserMonitoringTask(mockSnsClient, EventPublisherConfig("", "test"), validConfiguredCredentialTypes, searchMap).run(mockSession)
 
     verifyZeroInteractions(mockSnsClient)
   }
@@ -55,7 +56,7 @@ class UserMonitoringTaskSpec extends AnyFlatSpec with Matchers with MockitoSugar
 
     when(mockRealmModel.getName).thenReturn("testRealm")
     when(mockUserModelWithoutMFA.getId).thenReturn(userId)
-    when(mockUserProvider.getUsersStream(mockRealmModel)).thenReturn(java.util.stream.Stream.of(mockUserModelWithMFA, mockUserModelWithoutMFA))
+    when(mockUserProvider.searchForUserStream(mockRealmModel, searchMap)).thenReturn(java.util.stream.Stream.of(mockUserModelWithMFA, mockUserModelWithoutMFA))
     when(mockUserCredentialManagerWithMFA.isConfiguredFor(otpCredentialType)).thenReturn(true)
     when(mockUserCredentialManagerWithMFA.isConfiguredFor(webauthnCredentialType)).thenReturn(true)
     when(mockUserCredentialManagerWithoutMFA.isConfiguredFor(otpCredentialType)).thenReturn(false)
@@ -65,7 +66,7 @@ class UserMonitoringTaskSpec extends AnyFlatSpec with Matchers with MockitoSugar
     when(mockSession.realms()).thenReturn(mockRealmProvider)
     when(mockUserModelWithMFA.credentialManager()).thenReturn(mockUserCredentialManagerWithMFA)
     when(mockUserModelWithoutMFA.credentialManager()).thenReturn(mockUserCredentialManagerWithoutMFA)
-    new UserMonitoringTask(mockSnsClient, EventPublisherConfig(topicArn, "test"), validConfiguredCredentialTypes).run(mockSession)
+    new UserMonitoringTask(mockSnsClient, EventPublisherConfig(topicArn, "test"), validConfiguredCredentialTypes, searchMap).run(mockSession)
 
     val expectedMessage = """{
                              |  "tdrEnv" : "test",
@@ -94,7 +95,7 @@ class UserMonitoringTaskSpec extends AnyFlatSpec with Matchers with MockitoSugar
     when(mockRealmModel.getName).thenReturn("testRealm")
     when(mockUserModelWithoutMFA1.getId).thenReturn(userId)
     when(mockUserModelWithoutMFA2.getId).thenReturn(userId2)
-    when(mockUserProvider.getUsersStream(mockRealmModel)).thenReturn(java.util.stream.Stream.of(mockUserModelWithoutMFA1, mockUserModelWithoutMFA2))
+    when(mockUserProvider.searchForUserStream(mockRealmModel, searchMap)).thenReturn(java.util.stream.Stream.of(mockUserModelWithoutMFA1, mockUserModelWithoutMFA2))
     when(mockUserCredentialManagerWithoutMFA1.isConfiguredFor(otpCredentialType)).thenReturn(false)
     when(mockUserCredentialManagerWithoutMFA1.isConfiguredFor(webauthnCredentialType)).thenReturn(false)
     when(mockUserCredentialManagerWithoutMFA2.isConfiguredFor(otpCredentialType)).thenReturn(false)
@@ -104,7 +105,7 @@ class UserMonitoringTaskSpec extends AnyFlatSpec with Matchers with MockitoSugar
     when(mockSession.realms()).thenReturn(mockRealmProvider)
     when(mockUserModelWithoutMFA1.credentialManager()).thenReturn(mockUserCredentialManagerWithoutMFA1)
     when(mockUserModelWithoutMFA2.credentialManager()).thenReturn(mockUserCredentialManagerWithoutMFA2)
-    new UserMonitoringTask(mockSnsClient, EventPublisherConfig(topicArn, "test"), validConfiguredCredentialTypes).run(mockSession)
+    new UserMonitoringTask(mockSnsClient, EventPublisherConfig(topicArn, "test"), validConfiguredCredentialTypes, searchMap).run(mockSession)
 
     val expectedMessage = """{
                             |  "tdrEnv" : "test",
@@ -135,8 +136,8 @@ class UserMonitoringTaskSpec extends AnyFlatSpec with Matchers with MockitoSugar
     when(mockRealmModel2.getName).thenReturn("testRealm2")
     when(mockUserModelWithoutMFA1.getId).thenReturn(userId)
     when(mockUserModelWithoutMFA2.getId).thenReturn(userId2)
-    when(mockUserProvider.getUsersStream(mockRealmModel1)).thenReturn(java.util.stream.Stream.of(mockUserModelWithoutMFA1))
-    when(mockUserProvider.getUsersStream(mockRealmModel2)).thenReturn(java.util.stream.Stream.of(mockUserModelWithoutMFA2))
+    when(mockUserProvider.searchForUserStream(mockRealmModel1, searchMap)).thenReturn(java.util.stream.Stream.of(mockUserModelWithoutMFA1))
+    when(mockUserProvider.searchForUserStream(mockRealmModel2, searchMap)).thenReturn(java.util.stream.Stream.of(mockUserModelWithoutMFA2))
     when(mockUserCredentialManagerWithoutMFA1.isConfiguredFor(otpCredentialType)).thenReturn(false)
     when(mockUserCredentialManagerWithoutMFA1.isConfiguredFor(webauthnCredentialType)).thenReturn(false)
     when(mockUserCredentialManagerWithoutMFA2.isConfiguredFor(otpCredentialType)).thenReturn(false)
@@ -146,7 +147,7 @@ class UserMonitoringTaskSpec extends AnyFlatSpec with Matchers with MockitoSugar
     when(mockSession.realms()).thenReturn(mockRealmProvider)
     when(mockUserModelWithoutMFA1.credentialManager()).thenReturn(mockUserCredentialManagerWithoutMFA1)
     when(mockUserModelWithoutMFA2.credentialManager()).thenReturn(mockUserCredentialManagerWithoutMFA2)
-    new UserMonitoringTask(mockSnsClient, EventPublisherConfig(topicArn, "test"), validConfiguredCredentialTypes).run(mockSession)
+    new UserMonitoringTask(mockSnsClient, EventPublisherConfig(topicArn, "test"), validConfiguredCredentialTypes, searchMap).run(mockSession)
 
     val expectedMessage1 = """{
                             |  "tdrEnv" : "test",
@@ -179,14 +180,36 @@ class UserMonitoringTaskSpec extends AnyFlatSpec with Matchers with MockitoSugar
     val mockSnsClient = Mockito.mock(classOf[SnsClient])
 
     when(mockRealmModel.getName).thenReturn("testRealm")
-    when(mockUserProvider.getUsersStream(mockRealmModel)).thenReturn(java.util.stream.Stream.of(mockUserModel))
+    when(mockUserProvider.searchForUserStream(mockRealmModel, searchMap)).thenReturn(java.util.stream.Stream.of(mockUserModel))
     when(mockUserCredentialManager.isConfiguredFor(otpCredentialType)).thenReturn(false)
     when(mockUserCredentialManager.isConfiguredFor(webauthnCredentialType)).thenReturn(true)
     when(mockRealmProvider.getRealmsStream).thenReturn(java.util.stream.Stream.of(mockRealmModel))
     when(mockSession.users()).thenReturn(mockUserProvider)
     when(mockSession.realms()).thenReturn(mockRealmProvider)
     when(mockUserModel.credentialManager()).thenReturn(mockUserCredentialManager)
-    new UserMonitoringTask(mockSnsClient, EventPublisherConfig("", "test"), validConfiguredCredentialTypes).run(mockSession)
+    new UserMonitoringTask(mockSnsClient, EventPublisherConfig("", "test"), validConfiguredCredentialTypes, searchMap).run(mockSession)
+
+    verifyZeroInteractions(mockSnsClient)
+  }
+
+  "The run method" should "not send a message if only service account methods are missing MFA" in {
+    val mockSession = mock[KeycloakSession]
+    val mockRealmProvider = mock[RealmProvider]
+    val mockRealmModel = mock[RealmModel]
+    val mockUserCredentialManager = mock[SubjectCredentialManager]
+    val mockUserModel = mock[UserModel]
+    val mockUserProvider = mock[UserProvider]
+    val mockSnsClient = Mockito.mock(classOf[SnsClient])
+
+    when(mockRealmModel.getName).thenReturn("testRealm")
+    when(mockUserProvider.searchForUserStream(mockRealmModel, searchMap)).thenReturn(java.util.stream.Stream.of(mockUserModel))
+    when(mockUserCredentialManager.isConfiguredFor(otpCredentialType)).thenReturn(true)
+    when(mockUserCredentialManager.isConfiguredFor(webauthnCredentialType)).thenReturn(true)
+    when(mockRealmProvider.getRealmsStream).thenReturn(java.util.stream.Stream.of(mockRealmModel))
+    when(mockSession.users()).thenReturn(mockUserProvider)
+    when(mockSession.realms()).thenReturn(mockRealmProvider)
+    when(mockUserModel.getServiceAccountClientLink).thenReturn(null)
+    new UserMonitoringTask(mockSnsClient, EventPublisherConfig("", "test"), validConfiguredCredentialTypes, searchMap).run(mockSession)
 
     verifyZeroInteractions(mockSnsClient)
   }


### PR DESCRIPTION
Keycloak creates users for the service accounts and these are used by
things like the export and the backend checks and so can't be removed.

You can't log in as these users so they're safe without MFA so this
excludes them. There is a getServiceAccountClientLink method that is
null for non service accounts so we're filtering on that.

I've also replace the getUsersStream method with searchForUserStream as
getUsersStream is deprecated. I've updated the tests to reflect this and
added a test for the service account filter.
