### PR TITLE
Replace /tmp with /keycloak-configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,20 +2,20 @@ FROM quay.io/keycloak/keycloak:20.0.3
 USER root
 RUN microdnf update && microdnf install python3
 WORKDIR /opt/keycloak
+RUN mkdir /keycloak-configuration
 COPY quarkus.properties conf/
-COPY environment-properties /tmp/environment-properties
-COPY build.conf import_tdr_realm.py update_client_configuration.py update_realm_configuration.py tdr-realm-export.json /tmp/
+COPY environment-properties /keycloak-configuration/environment-properties
+COPY build.conf import_tdr_realm.py update_client_configuration.py update_realm_configuration.py tdr-realm-export.json /keycloak-configuration/
 COPY themes/tdr/login themes/tdr/login
 COPY themes/tdr/email themes/tdr/email
 COPY govuk-notify-spi/target/scala-2.13/govuk-notify-spi* providers/
 COPY credentials-provider/target/scala-2.13/credentials-provider.jar providers/
 COPY event-publisher-spi/target/scala-2.13/event-publisher-spi.jar providers/
 COPY keycloak.conf conf/
-RUN bin/kc.sh -cf /tmp/build.conf build
-RUN chown -R keycloak /tmp/environment-properties
-RUN chown keycloak /tmp/tdr-realm-export.json /tmp/import_tdr_realm.py
-RUN chmod +x /tmp/import_tdr_realm.py
+RUN bin/kc.sh -cf /keycloak-configuration/build.conf build
+RUN chown -R keycloak /keycloak-configuration
+RUN chmod +x /keycloak-configuration/import_tdr_realm.py
 USER 1000
 RUN mkdir -p data/import
 
-ENTRYPOINT /tmp/import_tdr_realm.py
+ENTRYPOINT /keycloak-configuration/import_tdr_realm.py

--- a/Dockerfile-update
+++ b/Dockerfile-update
@@ -2,8 +2,9 @@ FROM python:alpine
 RUN pip install requests
 RUN apk update \
     && apk upgrade zlib libtirpc expat
-COPY update_tdr_realm.py update_client_configuration.py update_realm_configuration.py /tmp/
-COPY environment-properties /tmp/environment-properties
-WORKDIR /tmp
-ENTRYPOINT wget --header "Authorization: token $GITHUB_TOKEN" https://raw.githubusercontent.com/nationalarchives/tdr-configurations/master/keycloak/tdr-realm-export.json && \
+RUN mkdir -p /opt/keycloak/data/import
+COPY update_tdr_realm.py update_client_configuration.py update_realm_configuration.py /keycloak-configuration/
+COPY environment-properties /keycloak-configuration/environment-properties
+WORKDIR /keycloak-configuration
+ENTRYPOINT wget --header "Authorization: token $GITHUB_TOKEN" https://raw.githubusercontent.com/nationalarchives/tdr-configurations/master/keycloak/tdr-realm-export.json  && \
            python update_tdr_realm.py $ENVIRONMENT $UPDATE_POLICY

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ To run, build and test locally:
     * Run the local docker image:
        ```
        [root directory] $ docker run -d --name [some name] -p 8081:8080 \
-       -e KEYCLOAK_ADMIN=admin -e KEYCLOAK_ADMIN_PASSWORD=admin -e KEYCLOAK_IMPORT=/tmp/tdr-realm.json \
+       -e KEYCLOAK_ADMIN=admin -e KEYCLOAK_ADMIN_PASSWORD=admin -e KEYCLOAK_IMPORT=/keycloak-configuration/tdr-realm.json \
        -e REALM_ADMIN_CLIENT_SECRET=[some value] -e CLIENT_SECRET=[some value] -e BACKEND_CHECKS_CLIENT_SECRET=[some value] \
        -e REPORTING_CLIENT_SECRET=[some value] \
        -e USER_ADMIN_CLIENT_SECRET=[some value] \

--- a/import_tdr_realm.py
+++ b/import_tdr_realm.py
@@ -7,5 +7,5 @@ from update_realm_configuration import update_realm_configuration
 env_properties_file = os.environ['KEYCLOAK_CONFIGURATION_PROPERTIES']
 host = os.environ['KEYCLOAK_HOST']
 
-update_realm_configuration('/tmp/', env_properties_file)
+update_realm_configuration('/keycloak-configuration/', env_properties_file)
 subprocess.call(['/opt/keycloak/bin/kc.sh', '-v', 'start'])

--- a/update_tdr_realm.py
+++ b/update_tdr_realm.py
@@ -34,7 +34,7 @@ def get_access_token():
     return access_token
 
 def get_realm_data():
-    update_realm_configuration('/tmp/', env_properties_file)
+    update_realm_configuration('/keycloak-configuration/', env_properties_file)
     with open('tdr-realm.json', 'r+') as realm:
         realm_data = json.load(realm)
     return realm_data
@@ -84,5 +84,5 @@ def update_realm():
     )
     print(f"Partial Import Response Status: {partial_result.status_code}")
 
-update_realm_configuration('/tmp/', env_properties_file)
+update_realm_configuration('/keycloak-configuration/', env_properties_file)
 update_realm()

--- a/update_tdr_realm.py
+++ b/update_tdr_realm.py
@@ -35,7 +35,7 @@ def get_access_token():
 
 def get_realm_data():
     update_realm_configuration('/keycloak-configuration/', env_properties_file)
-    with open('tdr-realm.json', 'r+') as realm:
+    with open('/opt/keycloak/data/import/tdr-realm.json', 'r+') as realm:
         realm_data = json.load(realm)
     return realm_data
 


### PR DESCRIPTION
The pen test had a low severity finding about using the /tmp directory.
Use the full path for the realm-export.json
This isn't related to the changes for the /tmp directory, it was broken anyway.
There is a ticket to look at replacing the keycloak-update task as this isn't working and doesn't help us update the configuration.
https://national-archives.atlassian.net/browse/TDR-2967
