### PR TITLE
Use multi stage build for Keycloak.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
-FROM quay.io/keycloak/keycloak:21.0.0
+FROM quay.io/keycloak/keycloak:21.0.1 as builder
+FROM registry.access.redhat.com/ubi9-minimal
+COPY --from=builder /opt/keycloak/ /opt/keycloak/
 USER root
-RUN microdnf update && microdnf install python3
+RUN microdnf update -y && \
+    microdnf -y install python3 java-17-openjdk-headless shadow-utils
+RUN useradd -U keycloak
 WORKDIR /opt/keycloak
 RUN mkdir /keycloak-configuration
 COPY quarkus.properties conf/


### PR DESCRIPTION
Keycloak are now using a micro version of the Redhat base image that
doesn't include a package manager. There is a comment against the PR for
that change which recommends using a base keycloak image and copying the
files over to an image that has microdnf installed.
https://github.com/keycloak/keycloak/pull/16879#issuecomment-1442069859

There are two other options.
ADD in a Dockerfile supports URLs so we could download the python source
and build Python into the image. This will take a long time for our
image builds though so isn't ideal. Also, I haven't tried it and there's
good chance a lot of the libraries needed to compile Python would be
missing so we'd be back to square one.

The other option is to re-write the python files in bash. This seems
like a lot of work.

The other issue is that there is a bug https://github.com/keycloak/keycloak/issues/17248
where it throws an exception if the admin theme is missing.
I've tried the workarounds on the ticket around adding a new theme but I
can't get it to work. We're not going to be updating the database
directly. They have said that the 21.0.1 release will have a fix for
this. I've tried the nightly build and the fix is in there so we now
just have to wait for 21.0.1 to release. The PR is ready for review
though.
