### PR TITLE
Revert the upgrade.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/keycloak/keycloak:21.0.0
+FROM quay.io/keycloak/keycloak:20.0.5
 USER root
 RUN microdnf update && microdnf install python3
 WORKDIR /opt/keycloak

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object Dependencies {
-  private val keycloakVersion = "21.0.0"
+  private val keycloakVersion = "20.0.5"
   private val circeVersion = "0.14.4"
 
   lazy val awsSecretsManager = "com.amazonaws.secretsmanager" % "aws-secretsmanager-caching-java" % "1.0.2"


### PR DESCRIPTION
There are problems with the new version. They should be fixed shortly
but until then we'll roll it back.

Related PR
https://github.com/nationalarchives/tdr-auth-server/pull/551
