### PR TITLE
Change the element link for the error.

### DIFF
--- a/themes/tdr/login/login-config-totp.ftl
+++ b/themes/tdr/login/login-config-totp.ftl
@@ -1,5 +1,5 @@
 <#import "template.ftl" as layout>
-<@layout.registrationLayout displayInfo=true displayRequiredFields=true; section>
+<@layout.registrationLayout displayInfo=true displayRequiredFields=true errorTarget="totp"; section>
 
     <#if section = "header">
         ${msg("loginTotpTitle")}

--- a/themes/tdr/login/login-otp.ftl
+++ b/themes/tdr/login/login-otp.ftl
@@ -1,5 +1,5 @@
 <#import "template.ftl" as layout>
-<@layout.registrationLayout; section>
+<@layout.registrationLayout errorTarget="otp"; section>
     <#if section="header">
         ${msg("doLogIn")}
     <#elseif section="form">

--- a/themes/tdr/login/login-reset-password.ftl
+++ b/themes/tdr/login/login-reset-password.ftl
@@ -1,7 +1,7 @@
 <#import "template.ftl" as layout>
 <#assign passwordResetPageTitle = msg("passwordReset")>
 
-<@layout.registrationLayout pageTitle=passwordResetPageTitle; section>
+<@layout.registrationLayout pageTitle=passwordResetPageTitle errorTarget="username"; section>
     <#if section = "header">
         ${passwordResetPageTitle}
     <#elseif section = "form">

--- a/themes/tdr/login/login-update-password.ftl
+++ b/themes/tdr/login/login-update-password.ftl
@@ -2,7 +2,7 @@
 <#assign updatePasswordPageTitle = msg("updatePasswordTitle")>
 <#assign hasError = (message?has_content && message.type = 'error')?then(true, false)>
 
-<@layout.registrationLayout pageTitle=updatePasswordPageTitle displayMessage=hasError; section>
+<@layout.registrationLayout pageTitle=updatePasswordPageTitle displayMessage=hasError errorTarget="password-new"; section>
     <#if section = "header">
         ${updatePasswordPageTitle}
     <#elseif section = "form">

--- a/themes/tdr/login/login.ftl
+++ b/themes/tdr/login/login.ftl
@@ -1,5 +1,5 @@
 <#import "template.ftl" as layout>
-<@layout.registrationLayout; section>
+<@layout.registrationLayout errorTarget="username"; section>
     <#if section = "header">
         ${msg("doLogIn")}
     <#elseif section = "form">

--- a/themes/tdr/login/template.ftl
+++ b/themes/tdr/login/template.ftl
@@ -4,7 +4,7 @@
 <#assign betaBannerLink = msg("betaBannerLink")>
 <#assign loggedInPageTitle = msg("loggedInTitle")>
 
-<#macro registrationLayout pageTitle=signInPageTitle displayInfo=false displayMessage=true displayRequiredFields=false showAnotherWayIfPresent=true>
+<#macro registrationLayout pageTitle=signInPageTitle displayInfo=false displayMessage=true displayRequiredFields=false showAnotherWayIfPresent=true errorTarget="error-kc-form-login">
     <!DOCTYPE html>
     <html xmlns="http://www.w3.org/1999/xhtml" lang="en" class="govuk-template">
     <head>
@@ -17,7 +17,12 @@
                 <meta name="${meta?split('==')[0]}" content="${meta?split('==')[1]}"/>
             </#list>
         </#if>
-        <title>${msg("loginTitle",(realm.displayName!''))}</title>
+        <#if displayMessage && message?has_content && message.type = 'error'>
+          <title>Error: ${msg("loginTitle",(realm.displayName!''))}</title>
+        <#else>
+          <title>${msg("loginTitle",(realm.displayName!''))}</title>
+        </#if>
+
         <link rel="icon" href="${url.resourcesPath}/img/favicon.ico"/>
         <#if properties.stylesCommon?has_content>
             <#list properties.stylesCommon?split(' ') as style>
@@ -75,30 +80,23 @@
         <main class="govuk-main-wrapper " id="main-content" role="main">
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-two-thirds">
-                    <h1 class="govuk-heading-l">
-                        <#if message?has_content && message.summary = msg("alreadyLoggedInMessage")>
-                            ${loggedInPageTitle}
-                        <#else>
-                            ${pageTitle}
-                        </#if>
-                    </h1>
                     <#-- Start TDR Error Messages -->
                     <#if displayMessage && message?has_content>
                         <#if message.type = 'error'>
                             <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert"
                                  tabindex="-1" data-module="govuk-error-summary">
                                 <h2 class="govuk-error-summary__title" id="error-summary-title">
-                                    There is a problem with this form
+                                    There is a problem
                                 </h2>
                                 <div class="govuk-error-summary__body">
                                     <ul class="govuk-list govuk-error-summary__list">
                                         <li>
                                             <#if message.summary = msg("webauthn-error-register-verification")>
-                                              <p>${msg("webauthn-error-register-verification")?no_esc}</p>
+                                                <p>${msg("webauthn-error-register-verification")?no_esc}</p>
                                             <#elseif message.summary = msg("webauthn-error-api-get")>
-                                              <p>${msg("webauthn-error-api-get")?no_esc}</p>
+                                                <p>${msg("webauthn-error-api-get")?no_esc}</p>
                                             <#else>
-                                              <a href="#error-kc-form-login">${message.summary}</a>
+                                                <a href="#${errorTarget}">${message.summary}</a>
                                             </#if>
                                         </li>
                                     </ul>
@@ -121,7 +119,13 @@
                         </#if>
                     </#if>
                     <#-- End TDR Error Messages -->
-
+                    <h1 class="govuk-heading-l">
+                        <#if message?has_content && message.summary = msg("alreadyLoggedInMessage")>
+                            ${loggedInPageTitle}
+                        <#else>
+                            ${pageTitle}
+                        </#if>
+                    </h1>
                     <#nested "form">
                 </div>
             </div>

--- a/themes/tdr/login/webauthn-authenticate.ftl
+++ b/themes/tdr/login/webauthn-authenticate.ftl
@@ -1,5 +1,5 @@
 <#import "template.ftl" as layout>
-<@layout.registrationLayout; section>
+<@layout.registrationLayout errorTarget="authenticateWebAuthnButton"; section>
     <#if section = "header">
         ${kcSanitize(msg("webauthn-login-title"))?no_esc}
     <#elseif section = "form">

--- a/themes/tdr/login/webauthn-register.ftl
+++ b/themes/tdr/login/webauthn-register.ftl
@@ -1,5 +1,5 @@
 <#import "template.ftl" as layout>
-<@layout.registrationLayout; section>
+<@layout.registrationLayout errorTarget="registerWebAuthn"; section>
     <#if section = "title">
       title
     <#elseif section = "form">


### PR DESCRIPTION
We were linking the error at the top of the page to #error-kc-form-login
which is the error on each individual page. The accessibility audit
found that we need to focus on the first input in the form when the
error link is clicked.

There's no way I can see to find out inside the templates which element
is the first in the form with the error and the error itself is in the
template so I've added in another parameter for the error target and
passed this in. It defaults to the value it was before so we'll have to
remember to pass it in if we ever do any more auth pages.

I've also moved the error above the h1 and added Error: to the page
title as per the report.
