### PR TITLE
Force upgrade of ssl

### DIFF
--- a/Dockerfile-update
+++ b/Dockerfile-update
@@ -1,7 +1,7 @@
 FROM python:alpine
 RUN pip install requests
 RUN apk update \
-    && apk upgrade zlib libtirpc expat
+    && apk upgrade zlib libtirpc expat openssl
 RUN mkdir -p /opt/keycloak/data/import
 COPY update_tdr_realm.py update_client_configuration.py update_realm_configuration.py /keycloak-configuration/
 COPY environment-properties /keycloak-configuration/environment-properties


### PR DESCRIPTION
This is in anticipation of an ssl upgrade to resolve: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-1255

Currently there isn't a fix, so the the ECR alert will continue