### PR TITLE
Upgrade the github actions java runtime

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,10 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'temurin'
       - uses: nationalarchives/tdr-github-actions/.github/actions/run-git-secrets@main
       - uses: nationalarchives/tdr-github-actions/.github/actions/slack-send@main
         if: failure()
@@ -23,6 +19,10 @@ jobs:
           message: ":warning: Secrets found in repository ${{ inputs.repo-name }}"
           slack-url: ${{ secrets.SLACK_WEBHOOK }}
       - uses: coursier/cache-action@v6
+      - uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
       - run: |
           npm install
           npm run checks

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   id-token: write
   contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -19,11 +20,4 @@ jobs:
           message: ":warning: Secrets found in repository ${{ inputs.repo-name }}"
           slack-url: ${{ secrets.SLACK_WEBHOOK }}
       - uses: coursier/cache-action@v6
-      - uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-      - run: |
-          npm install
-          npm run checks
-          sbt scalastyle test
+      - run: ${{ inputs.test-command }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,12 +9,21 @@ permissions:
   contents: read
 jobs:
   test:
-    uses: nationalarchives/tdr-github-actions/.github/workflows/tdr_test.yml@main
-    with:
-      repo-name: tdr-auth-server
-      test-command: |
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+    - uses: nationalarchives/tdr-github-actions/.github/actions/run-git-secrets@main
+    - uses: nationalarchives/tdr-github-actions/.github/actions/slack-send@main
+      if: failure()
+      with:
+        message: ":warning: Secrets found in repository ${{ inputs.repo-name }}"
+        slack-url: ${{ secrets.SLACK_WEBHOOK }}
+      - uses: coursier/cache-action@v6
+      - run: |
         npm install
         npm run checks
         sbt scalastyle test
-    secrets:
-      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,6 @@
 name: TDR Run Auth Server Tests
 on:
+  pull_request:
   push:
     branches-ignore:
       - master
@@ -11,6 +12,7 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    environment: intg
     steps:
       - uses: actions/checkout@v3
       - uses: nationalarchives/tdr-github-actions/.github/actions/run-git-secrets@main
@@ -20,4 +22,11 @@ jobs:
           message: ":warning: Secrets found in repository ${{ inputs.repo-name }}"
           slack-url: ${{ secrets.SLACK_WEBHOOK }}
       - uses: coursier/cache-action@v6
-      - run: ${{ inputs.test-command }}
+      - uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+      - run: |
+          npm install
+          npm run checks
+          sbt scalastyle test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,17 @@
 name: TDR Run Auth Server Tests
 on:
+  workflow_call:
+    inputs:
+      java-version:
+        required: false
+        type: string
+        description: ''
   pull_request:
   push:
     branches-ignore:
       - master
       - release-*
+
 permissions:
   id-token: write
   contents: read
@@ -21,6 +28,7 @@ jobs:
           message: ":warning: Secrets found in repository ${{ inputs.repo-name }}"
           slack-url: ${{ secrets.SLACK_WEBHOOK }}
       - uses: coursier/cache-action@v6
+        if: inputs.java-version != '' || inputs.java-version != '11'
       - uses: actions/setup-java@v3
         with:
           java-version: '17'
@@ -29,3 +37,8 @@ jobs:
           npm install
           npm run checks
           sbt scalastyle test
+        if: inputs.java-version == '' || inputs.java-version == '11'
+      - run: |
+          npm install
+          npm run checks
+          sbt scalastyle test  

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,6 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
-    environment: intg
     steps:
       - uses: actions/checkout@v3
       - uses: nationalarchives/tdr-github-actions/.github/actions/run-git-secrets@main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,19 +11,19 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-java@v3
-      with:
-        java-version: '17'
-        distribution: 'temurin'
-    - uses: nationalarchives/tdr-github-actions/.github/actions/run-git-secrets@main
-    - uses: nationalarchives/tdr-github-actions/.github/actions/slack-send@main
-      if: failure()
-      with:
-        message: ":warning: Secrets found in repository ${{ inputs.repo-name }}"
-        slack-url: ${{ secrets.SLACK_WEBHOOK }}
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+      - uses: nationalarchives/tdr-github-actions/.github/actions/run-git-secrets@main
+      - uses: nationalarchives/tdr-github-actions/.github/actions/slack-send@main
+        if: failure()
+        with:
+          message: ":warning: Secrets found in repository ${{ inputs.repo-name }}"
+          slack-url: ${{ secrets.SLACK_WEBHOOK }}
       - uses: coursier/cache-action@v6
       - run: |
-        npm install
-        npm run checks
-        sbt scalastyle test
+          npm install
+          npm run checks
+          sbt scalastyle test


### PR DESCRIPTION
The latest versions of the Keycloak libraries (22.0.0) are built with java runtime 61

The default github actions java version is currently 11: https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md#java

This java version is incompatible with java runtime 61 leading to compilation errors in the test, build and deploy actions

Upgrade the default java version to 17 on the github actions which is compatible with java runtime 61

Unable to use the 'coursier/setup-action@v3' set to set the java version as it appears it does not support java version 17

Use the 'actions/setup-java@v3' which does support java 17: https://github.com/marketplace/actions/setup-java-jdk