### PR TITLE
Fix assignment of value to 'page title'

### DIFF
--- a/themes/tdr/login/login-reset-password.ftl
+++ b/themes/tdr/login/login-reset-password.ftl
@@ -1,12 +1,11 @@
 <#import "template.ftl" as layout>
-<#assign tdrPasswordResetPageTitle = msg("tdrPasswordReset")>
-<#assign passwordResetPageTitle = msg("passwordReset")>
-
-#if properties.blockSharedPages = 'true'>
-<@layout.registrationLayout pageTitle=tdrPasswordResetPageTitle errorTarget="username"; section>
+<#if properties.blockSharedPages = 'true'>
+    <#assign passwordResetPageTitle = msg("tdrPasswordReset")>
 <#else>
-<@layout.registrationLayout pageTitle=passwordResetPageTitle errorTarget="username"; section>
+    <#assign passwordResetPageTitle = msg("passwordReset")>
 </#if>
+
+<@layout.registrationLayout pageTitle=passwordResetPageTitle errorTarget="username"; section>
     <#if section = "header">
         <#if properties.blockSharedPages = 'true'>
             ${tdrPasswordResetPageTitle}


### PR DESCRIPTION
'If / Else' statement assigning value to the 'page title' was causing an FTL template compilation error

Assign the the value first and use single variable in the 'layout registration'