### PR TITLE
TDRD 19: Fix icons for success and info messages

### DIFF
--- a/themes/tdr/login/template.ftl
+++ b/themes/tdr/login/template.ftl
@@ -153,10 +153,11 @@
                             </div>
                         <#else>
                             <div class="govuk-warning-text" aria-labelledby="warning-message" role="alert" tabindex="-1">
-                                <#if message.type = 'success'><span
-                                    class="${properties.kcFeedbackSuccessIcon!}"></span></#if>
-                                <#if message.type = 'warning'><span class="govuk-warning-text__icon" aria-hidden="true">!</span></#if>
-                                <#if message.type = 'info'><span class="${properties.kcFeedbackInfoIcon!}"></span></#if>
+                                <span class="govuk-warning-text__icon" aria-hidden="true">
+                                    <#if message.type = 'success'>&#10003;<#-- checkmark --></#if>
+                                    <#if message.type = 'warning'>!</#if>
+                                    <#if message.type = 'info'>i</#if>
+                                </span>
                                 <strong class="govuk-warning-text__text" id="warning-message">
                                     <span class="govuk-warning-text__assistive">Warning</span>
                                     ${message.summary}


### PR DESCRIPTION
Was initially looking for a regression here, but it seems possible that `kc*` properties have never been successfully picked up and this is has not been especially noticeable as the most common message case (`warning`) uses govuk css.

As far as I could understand from reading up on keycloak themes, `parent=base` in the properties file only gives access to keycloak template files, rather than keycloak css theme styling, for which `parent=keycloak` is required. I tested this locally, and switching to `parent=keycloak` does indeed yield the expected class attributes specified in the keycloak theme source (`fa fa-fw fa-check-circle`), but it doesn't play nicely with the gov component, giving a very small icon which is not aligned with the warning text.

With this in mind, I've updated to use the same html component for each message case, simply switching the character displayed inside the span.

This is all new territory to me though, so anything obvious I've missed, do let me know!

---

### Test Plan

Ran keycloak locally before and after changes- verified icon displaying as desired after submitting password reset request.

|Before|After|
|---|---|
|![Screenshot from 2024-02-27 15-33-23](https://github.com/nationalarchives/tdr-auth-server/assets/16852485/c6511c2c-0ffb-4146-bc4c-322bb62de201)|![Screenshot from 2024-02-27 15-17-20](https://github.com/nationalarchives/tdr-auth-server/assets/16852485/95e19f29-e7cf-435c-97fe-c69df2d77431)|
