### PR TITLE
Downgrade Keycloak version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/keycloak/keycloak:24.0.1 as builder
+FROM quay.io/keycloak/keycloak:23.0.7 as builder
 FROM registry.access.redhat.com/ubi9-minimal
 COPY --from=builder /opt/keycloak/ /opt/keycloak/
 USER root


### PR DESCRIPTION
Latest version of Keycloak '24.0.1' causing ECS task start up to fail

Downgrade until can fix issue