### PR TITLE
Allow HTTP

### DIFF
--- a/keycloak.conf
+++ b/keycloak.conf
@@ -1,5 +1,6 @@
 hostname=${KEYCLOAK_HOST}
 proxy=edge
+http-enabled=true
 log-console-output=json
 spi-events-listener-jboss-logging-success-level=info
 spi-events-listener-jboss-logging-error-level=warn


### PR DESCRIPTION
Keycloak sits behind the load balancer which requires https

On the vpc Keycloak uses http for now

This allows the continuing of traffic within the vpc using http