### PR TITLE
Allow for dynamic resolution of backend URLs

### DIFF
--- a/keycloak.conf
+++ b/keycloak.conf
@@ -10,3 +10,4 @@ spi-events-listener-event-publisher-enabled=true
 spi-events-listener-jboss-logging-enabled=true
 features=client-secret-rotation,admin-fine-grained-authz
 health-enabled=true
+hostname-backchannel-dynamic=true


### PR DESCRIPTION
Keycloak restart failing to get to a 'healthy' state following upgrade

This may resolve this following the changes to Keycloaks hostname strategy: https://www.keycloak.org/docs/latest/upgrading/#migrating-to-25-0-0