### PR TITLE
Upgrade to latest version 25 point release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/keycloak/keycloak:25.0.0 as builder
+FROM quay.io/keycloak/keycloak:25.0.4 as builder
 FROM registry.access.redhat.com/ubi9-minimal
 COPY --from=builder /opt/keycloak/ /opt/keycloak/
 USER root


### PR DESCRIPTION
Issue with the first version 25 point release not exposing the new management port 9000 correctly causing health checks to fail

This should resolve the issues with StatusCake not being able to find the 'health' endpoint