### PR TITLE
'proxy' configuration option removed in v26

### DIFF
--- a/keycloak.conf
+++ b/keycloak.conf
@@ -1,5 +1,5 @@
 hostname=${KEYCLOAK_HOST}
-proxy=edge
+proxy-headers=forwarded
 http-enabled=true
 log-console-output=json
 spi-events-listener-jboss-logging-success-level=info


### PR DESCRIPTION
See upgrade guide: https://www.keycloak.org/docs/latest/upgrading/index.html#deprecated-proxy-option