### PR TITLE
This fixes `CVE-2025-26519` & `CVE-2025-31115`

### DIFF
--- a/Dockerfile-update
+++ b/Dockerfile-update
@@ -1,7 +1,6 @@
 FROM python:3.13.1-alpine3.19
 RUN pip install requests
-RUN apk update \
-    && apk upgrade zlib libtirpc expat openssl libcrypto3 libssl3
+RUN apk update && apk upgrade
 RUN mkdir -p /opt/keycloak/data/import
 COPY update_tdr_realm.py update_client_configuration.py update_realm_configuration.py /keycloak-configuration/
 COPY environment-properties /keycloak-configuration/environment-properties


### PR DESCRIPTION
Alpine Linux uses musl, not glibc – so CVE-2025-26519 (glibc) does not apply to Alpine.
CVE-2025-31115 (xz-utils) does affect Alpine, but Alpine 3.19 received patched versions