### PR TITLE
Roll back Keycloak version upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/keycloak/keycloak:26.4.0 as builder
+FROM quay.io/keycloak/keycloak:26.3.4 as builder
 FROM registry.access.redhat.com/ubi9-minimal
 COPY --from=builder /opt/keycloak/ /opt/keycloak/
 USER root


### PR DESCRIPTION
Latest version of Keycloak v26.4.0 appears to be causing the health checks to fail so the ECS container fails to start

Rolling the version back temporarily until the issue can be investigated and fixed.