### PR TITLE
TDRD-1398 Fix package.json using old v4 path

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Repository for TDR Auth Server code",
   "private": true,
   "scripts": {
-    "copy-govuk-image-assets": "copyfiles -f node_modules/govuk-frontend/govuk/assets/images/* ./themes/tdr/$npm_config_theme/resources/img -e node_modules/govuk-frontend/govuk/assets/images/favicon*",
-    "copy-govuk-js-assets": "copyfiles -f node_modules/govuk-frontend/govuk/all.js ./themes/tdr/$npm_config_theme/resources/js",
+    "copy-govuk-image-assets": "copyfiles -f \"node_modules/govuk-frontend/dist/govuk/assets/images/govuk-*\" ./themes/tdr/$npm_config_theme/resources/img",
+    "copy-govuk-js-assets": "copyfiles -f node_modules/govuk-frontend/dist/govuk/all.bundle.js ./themes/tdr/$npm_config_theme/resources/js",
     "copy-assets": "npm-run-all copy-govuk-image-assets copy-govuk-js-assets",
     "sass-compile": "sass --no-source-map ./themes/tdr/css-src/sass/main.scss ./themes/tdr/$npm_config_theme/resources/css/main.css",
     "add-stylesheet-dir": "mkdir -p ./themes/tdr/$npm_config_theme/resources/css",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,7 +16,7 @@ object Dependencies {
   lazy val keycloakModelJpa: ModuleID = "org.keycloak" % "keycloak-model-jpa" % keycloakVersion % "provided"
   lazy val keycloakServerSpi: ModuleID = "org.keycloak" % "keycloak-server-spi" % keycloakVersion % "provided"
   lazy val mockito: ModuleID = "org.mockito" %% "mockito-scala" % "2.1.0"
-  lazy val notifyJavaClient: ModuleID = "uk.gov.service.notify" % "notifications-java-client" % "6.0.0-RELEASE" 
+  lazy val notifyJavaClient: ModuleID = "uk.gov.service.notify" % "notifications-java-client" % "6.0.0-RELEASE"
   lazy val quarkusCredentials = "io.quarkus" % "quarkus-credentials" % "3.34.3"
   lazy val rds = "software.amazon.awssdk" % "rds" % "2.26.27"
   lazy val scalaCache = "com.github.cb372" %% "scalacache-caffeine" % "0.28.0"

--- a/themes/tdr/login/theme.properties
+++ b/themes/tdr/login/theme.properties
@@ -1,7 +1,7 @@
 parent=base
 import=common/keycloak
 styles=css/main.css
-scripts=js/all.js js/webauthn.js
+scripts=js/all.bundle.js js/webauthn.js
 
 meta=viewport==width=device-width,initial-scale=1.0==
 


### PR DESCRIPTION
The 404 for css/main.css may be caused by the build breaking silently due to a govuk-frontend v4 → v5 migration mismatch in package.json. The project is on v5.10.2 where the file moved to dist/govuk/all.bundle.js.