### PR TITLE
Fix gzip cache dir ownership for Keycloak 26.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ COPY event-publisher-spi/target/scala-2.13/event-publisher-spi.jar providers/
 COPY custom-response-provider/target/scala-2.13/custom-response-provider.jar providers/
 COPY keycloak.conf conf/
 RUN bin/kc.sh -cf /keycloak-configuration/build.conf build
+RUN chown -R 1000:1000 /opt/keycloak/data
 RUN chown -R keycloak /keycloak-configuration
 RUN chmod +x /keycloak-configuration/import_tdr_realm.py
 USER 1000


### PR DESCRIPTION
Keycloak 26.6 creates data/tmp with root ownership during build. At runtime (USER 1000), GzipResourceEncodingProviderFactory cannot write to the cache dir, causing 404s for theme CSS/JS resources when browsers send Accept-Encoding: gzip.

Fix: chown data/ to runtime user after kc.sh build.

See: https://github.com/keycloak/keycloak/issues/48365